### PR TITLE
Add file writer and update engineer/orchestrator

### DIFF
--- a/agents/engineer.py
+++ b/agents/engineer.py
@@ -2,13 +2,15 @@ from langchain_community.llms import Ollama
 
 
 def run_engineer(design: str, context: str) -> str:
-    """Generate code implementation based on design and context."""
+    """Generate code implementation along with target file path."""
     prompt = (
         "You are the software engineer AI. "
-        "Implement the following design using the given context.\n"\
-        f"Design:\n{design}\n"\
-        f"Context:\n{context}\n"\
-        "Provide the code snippet or instructions." 
+        "Implement the following design using the given context.\n"
+        f"Design:\n{design}\n"
+        f"Context:\n{context}\n"
+        "Respond ONLY in the following format:\n"
+        "FILE: <path/to/File.java>\n"
+        "CODE:\n<your code here>"
     )
     llm = Ollama(model="mistral")
     return llm.invoke(prompt)

--- a/file_writer.py
+++ b/file_writer.py
@@ -1,0 +1,35 @@
+import os
+
+
+def write_code_file(target_path: str, code: str, dry_run: bool = False) -> None:
+    """Write or append code to a .java file under the codebase directory.
+
+    Parameters
+    ----------
+    target_path: str
+        Relative path to the .java file within the project (without the
+        leading 'codebase/').
+    code: str
+        The Java code to write or append.
+    dry_run: bool, optional
+        If True, only print the intended actions without modifying files.
+    """
+    # Ensure path is relative and join with base codebase directory
+    target_path = target_path.lstrip("/\\")
+    base_dir = "codebase"
+    full_path = os.path.join(base_dir, target_path)
+    dir_name = os.path.dirname(full_path)
+
+    if dry_run:
+        action = "create" if not os.path.exists(full_path) else "update"
+        print(f"[DRY RUN] Would {action} file: {full_path}")
+        return
+
+    os.makedirs(dir_name, exist_ok=True)
+    exists = os.path.exists(full_path)
+
+    with open(full_path, "a" if exists else "w", encoding="utf-8") as f:
+        f.write(code.rstrip("\n") + "\n")
+
+    status = "Updated" if exists else "Created"
+    print(f"\u2705 {status} file: {full_path}")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Tuple
 
 from indexer import index_codebase, load_index
 from retriever import retrieve_relevant_chunks
@@ -6,6 +6,25 @@ from agents.architect import run_architect
 from agents.engineer import run_engineer
 from agents.reviewer import run_reviewer
 from agents.tester import run_tester
+from file_writer import write_code_file
+
+
+def parse_engineer_output(output: str) -> Tuple[str, str]:
+    """Extract file path and code from engineer agent output."""
+    file_path = ""
+    code_lines = []
+    in_code = False
+    for line in output.splitlines():
+        if line.startswith("FILE:"):
+            file_path = line[len("FILE:"):].strip()
+        elif line.strip() == "CODE:" or line.startswith("CODE:"):
+            in_code = True
+            if line.strip() != "CODE:":
+                code_lines.append(line.split("CODE:",1)[1])
+        elif in_code:
+            code_lines.append(line)
+    code = "\n".join(code_lines).strip()
+    return file_path, code
 
 
 def process_feature_request(request: str) -> Dict[str, str]:
@@ -18,13 +37,17 @@ def process_feature_request(request: str) -> Dict[str, str]:
     context = "\n".join(chunk["text"] for chunk in retrieved)
 
     design = run_architect(request, context)
-    code = run_engineer(design, context)
+    engineer_output = run_engineer(design, context)
+    file_path, code = parse_engineer_output(engineer_output)
+    if file_path:
+        write_code_file(file_path, code)
+
     review = run_reviewer(code, context)
     tests = run_tester(code, context)
 
     return {
         "design": design,
-        "code": code,
+        "code": engineer_output,
         "review": review,
         "tests": tests,
     }


### PR DESCRIPTION
## Summary
- engineer agent now outputs a file path and code snippet format
- new `file_writer.py` handles creating/updating Java files
- orchestrator parses engineer output and writes to `codebase`

## Testing
- `python -m py_compile file_writer.py orchestrator.py agents/engineer.py`
- `pip install -q -r requirements.txt`
- `python main.py` *(fails: Connection refused to Ollama model)*

------
https://chatgpt.com/codex/tasks/task_e_6885234027f0832b80868aed587b3bad